### PR TITLE
Change seconds to ms in the report 

### DIFF
--- a/load-test-timing.js
+++ b/load-test-timing.js
@@ -117,7 +117,7 @@ const action = async (context, data) => {
 
   const header = `
       <header>
-        <b># Iterations:</b> [${numIterations}] <b>Delay between requests:</b> [${delayBetweenRequests}s] <b>Run:</b> 
+        <b># Iterations:</b> [${numIterations}] <b>Delay between requests:</b> [${delayBetweenRequests}ms] <b>Run:</b> 
         [${runInParallel ? "in Parallel" : "Serially"}]
       </header>`;
 


### PR DESCRIPTION
Change seconds to ms in the report when displaying delayBetweenRequests currently it is displayd as seconds but the actual unit is ms.

```
Iterations: [50] Delay between requests: [5000s] Run: [in Parallel]
                                          ___ ^___
```
![Screenshot 2022-01-18 at 16 37 33](https://user-images.githubusercontent.com/26549236/149979522-43223342-2bab-4158-9686-b18609512c98.png)

